### PR TITLE
Update weekly report format to Sunday-Saturday

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Follow `/Users/sisu/.claude/commands/writing_guideline.md`:
 ```
 
 This will:
-1. Calculate previous week's dates (Monday-Sunday)
+1. Calculate previous week's dates (Sunday-Saturday)
 2. Check if folder exists (prompt if yes)
 3. Run parallel data collection
 4. Generate sections in parallel
@@ -102,20 +102,20 @@ This will:
 ### Date Calculation
 ```bash
 date +"%Y-%m-%d %A"  # Get current date
-# Calculate Monday-Sunday of previous week
+# Calculate Sunday-Saturday of previous week
 ```
 
 ### Folder Setup
 ```bash
-mkdir -p YYYYMMDD-YYYYMMDD  # Create week folder
+mkdir -p YYYYMMDD-YYYYMMDD  # Create week folder (e.g., 20250824-20250830)
 ```
 
 ### Parallel Task Launch Example
 ```python
 # Launch ALL at once (correct)
-Task("GitHub collection", ..., writes_to="20250826-20250901/github_raw.json")
-Task("Slack collection", ..., writes_to="20250826-20250901/slack_raw.json")
-Task("Gmail collection", ..., writes_to="20250826-20250901/gmail_raw.json")
+Task("GitHub collection", ..., writes_to="20250824-20250830/github_raw.json")
+Task("Slack collection", ..., writes_to="20250824-20250830/slack_raw.json")
+Task("Gmail collection", ..., writes_to="20250824-20250830/gmail_raw.json")
 # ... all 7 tasks in one message
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run with Claude Code:
 ```
 
 This will:
-1. Calculate date range (default: previous Monday-Sunday)
+1. Calculate date range (default: previous Sunday-Saturday)
 2. Create folder `YYYYMMDD-YYYYMMDD/`
 3. Collect data from all sources in parallel
 4. Generate report sections
@@ -40,7 +40,7 @@ This will:
 
 Specify custom dates when prompted:
 ```
-"Generate report for 2025-08-26 to 2025-09-01"
+"Generate report for 2025-08-24 to 2025-08-30"
 ```
 
 ## Report Structure

--- a/go.md
+++ b/go.md
@@ -7,7 +7,7 @@ Document principal-level engineering work including technical leadership, archit
 
 ## Usage
 
-To generate last week's report (Monday-Sunday):
+To generate last week's report (Sunday-Saturday):
 ```bash
 # Run this prompt with Claude Code
 # Automatically calculates last week's dates and generates the report
@@ -15,7 +15,7 @@ To generate last week's report (Monday-Sunday):
 
 To generate a custom date range report:
 ```bash
-# Specify custom dates: "2025-08-26 to 2025-09-01"
+# Specify custom dates: "2025-08-24 to 2025-08-30"
 ```
 
 ## Report Generation Process
@@ -25,10 +25,10 @@ To generate a custom date range report:
 # Get current date
 date +"%Y-%m-%d %A"
 
-# Calculate last week's date range (Monday to Sunday)
-# If today is 2025-09-06 (Friday), last week would be:
-# Monday: 2025-08-26
-# Sunday: 2025-09-01
+# Calculate last week's date range (Sunday to Saturday)
+# If today is 2025-09-05 (Friday), last week would be:
+# Sunday: 2025-08-24
+# Saturday: 2025-08-30
 ```
 
 ### Step 2: Data Collection Commands
@@ -292,9 +292,9 @@ Create the report in `reports/YYYYMMDD-YYYYMMDD.md` format with the following st
 When executing this prompt with Claude:
 
 ### 1. **Calculate dates**: 
-   - Default: Previous Monday-Sunday
+   - Default: Previous Sunday-Saturday
    - Custom: Parse provided range
-   - Format: YYYYMMDD-YYYYMMDD (e.g., 20250826-20250901)
+   - Format: YYYYMMDD-YYYYMMDD (e.g., 20250824-20250830)
 
 ### 2. **Setup**:
    
@@ -319,7 +319,7 @@ When executing this prompt with Claude:
        # Option 3: Exit without doing anything
    else
        # Create new folder
-       mkdir -p YYYYMMDD-YYYYMMDD  # Example: 20250826-20250901
+       mkdir -p YYYYMMDD-YYYYMMDD  # Example: 20250824-20250830
    fi
    ```
 
@@ -397,26 +397,26 @@ When executing this prompt with Claude:
 ```python
 # CORRECT: Parallel execution (what Claude should do)
 # Launch ALL these tasks in a single message with multiple tool calls
-# Example: For week 20250826-20250901
-Task("GitHub data collection", collect_github_data, writes_to="20250826-20250901/github_raw.json")
-Task("Slack data collection", collect_slack_data, writes_to="20250826-20250901/slack_raw.json")
-Task("Gmail data collection", collect_gmail_data, writes_to="20250826-20250901/gmail_raw.json")
-Task("Calendar data collection", collect_calendar_data, writes_to="20250826-20250901/calendar_raw.json")
-Task("Linear data collection", collect_linear_data, writes_to="20250826-20250901/linear_raw.json")
-Task("Drive data collection", collect_drive_data, writes_to="20250826-20250901/drive_raw.json")
-Task("LaunchDarkly data collection", collect_ld_data, writes_to="20250826-20250901/launchdarkly_raw.json")
+# Example: For week 20250824-20250830
+Task("GitHub data collection", collect_github_data, writes_to="20250824-20250830/github_raw.json")
+Task("Slack data collection", collect_slack_data, writes_to="20250824-20250830/slack_raw.json")
+Task("Gmail data collection", collect_gmail_data, writes_to="20250824-20250830/gmail_raw.json")
+Task("Calendar data collection", collect_calendar_data, writes_to="20250824-20250830/calendar_raw.json")
+Task("Linear data collection", collect_linear_data, writes_to="20250824-20250830/linear_raw.json")
+Task("Drive data collection", collect_drive_data, writes_to="20250824-20250830/drive_raw.json")
+Task("LaunchDarkly data collection", collect_ld_data, writes_to="20250824-20250830/launchdarkly_raw.json")
 
 # Wait for all to complete...
 
 # Then launch section generation in parallel
-Task("Generate technical section", analyze_technical_data, reads=["20250826-20250901/github_raw.json", "20250826-20250901/launchdarkly_raw.json"])
-Task("Generate collaboration section", analyze_collab_data, reads=["20250826-20250901/slack_raw.json", "20250826-20250901/gmail_raw.json"])
-Task("Generate strategic section", analyze_strategic_data, reads=["20250826-20250901/linear_raw.json", "20250826-20250901/calendar_raw.json"])
+Task("Generate technical section", analyze_technical_data, reads=["20250824-20250830/github_raw.json", "20250824-20250830/launchdarkly_raw.json"])
+Task("Generate collaboration section", analyze_collab_data, reads=["20250824-20250830/slack_raw.json", "20250824-20250830/gmail_raw.json"])
+Task("Generate strategic section", analyze_strategic_data, reads=["20250824-20250830/linear_raw.json", "20250824-20250830/calendar_raw.json"])
 
 # Wait for all sections...
 
 # Finally, generate executive summary with full context
-Task("Generate executive summary and final report", create_final_report, reads=all_files_in_folder, writes_to="20250826-20250901/weekly_report.md")
+Task("Generate executive summary and final report", create_final_report, reads=all_files_in_folder, writes_to="20250824-20250830/weekly_report.md")
 ```
 
 ```python


### PR DESCRIPTION
## Summary
- Updated weekly report format from Monday-Sunday to Sunday-Saturday
- Fixed date calculations and examples throughout documentation
- Corrected folder naming convention to match new format

## Changes
- Changed date range calculation to use Sunday-Saturday format
- Updated all example dates to use correct week (Aug 24-30, 2025) when today is Friday Sep 5, 2025
- Fixed folder naming from `20250826-20250901` to `20250824-20250830`
- Updated README.md and CLAUDE.md documentation
- Removed incorrectly created folder with old date format

## Rationale
This aligns with standard weekly reporting periods that start on Sunday and end on Saturday, making it easier to track complete weeks of work.

🤖 Generated with Claude Code